### PR TITLE
Minimal fix for JRUBY-6715

### DIFF
--- a/src/java/org/jruby/ext/openssl/x509store/Lookup.java
+++ b/src/java/org/jruby/ext/openssl/x509store/Lookup.java
@@ -555,7 +555,7 @@ public class Lookup {
                 int tp = iter.next();
                 int k = 0;
                 for(;;) {
-                    b.append(String.format("%s/%08x.%s%d", cdir, h, postfix, k));
+                    b.append(String.format("%s%s%08x.%s%d", cdir, File.separator, h, postfix, k));
                     k++;
                     if(!(new File(b.toString()).exists())) {
                         break;


### PR DESCRIPTION
This change replaces a hardcoded slash, used for file path creation, with the system-dependent default name-separator character provided by the File class. This fixes the use of SSL_CERT_DIR under Windows.

See https://jira.codehaus.org/browse/JRUBY-6715
