### PR TITLE
Added support for the Java cacerts trust anchors

### DIFF
--- a/src/java/org/jruby/ext/openssl/X509Store.java
+++ b/src/java/org/jruby/ext/openssl/X509Store.java
@@ -160,6 +160,9 @@ public class X509Store extends RubyObject {
             store.loadLocations(file, null);
             String path = (String)env.get(getRuntime().newString(X509Utils.getDefaultCertificateDirectoryEnvironment()));
             store.loadLocations(null, path);
+            if (file == null && path == null) { 
+                store.setDefaultPaths();
+            }
         }
         catch(Exception e) {
             raise("setting default path failed: " + e.getMessage());

--- a/src/java/org/jruby/ext/openssl/x509store/Lookup.java
+++ b/src/java/org/jruby/ext/openssl/x509store/Lookup.java
@@ -52,6 +52,11 @@ import org.jruby.util.io.FileExistsException;
 import org.jruby.util.io.InvalidValueException;
 import org.jruby.util.io.ModeFlags;
 
+
+import java.security.KeyStore;
+import java.security.cert.PKIXParameters;
+import java.security.cert.TrustAnchor;
+
 /**
  * X509_LOOKUP
  *
@@ -264,6 +269,31 @@ public class Lookup {
         return count; 
     }
 
+    public int loadDefaultJavaCACertsFile() throws Exception {
+        int count = 0;
+        String certsFile = System.getProperty("java.home") + "/lib/security/cacerts".replace('/', File.separatorChar);
+        FileInputStream fin = new FileInputStream(certsFile);
+        try {
+            KeyStore keystore = KeyStore.getInstance(KeyStore.getDefaultType());
+            // we pass a null password, as the cacerts file isn't password protected
+            keystore.load(fin, null);
+            PKIXParameters params = new PKIXParameters(keystore);
+            for(TrustAnchor trustAnchor : params.getTrustAnchors()) {
+                X509Certificate certificate = trustAnchor.getTrustedCert();
+                store.addCertificate(certificate);
+                count++;
+            }    
+        } finally {
+            if (fin != null) {
+                try {
+                    fin.close();
+                } catch (Exception ignored) {
+                }
+            }
+        }
+        return count;
+    }
+
     private InputStream wrapJRubyNormalizedInputStream(String file) throws IOException {
         Ruby runtime = Ruby.getGlobalRuntime();
         try {
@@ -404,7 +434,7 @@ public class Lookup {
                     if (file != null) {
                         ok = ctx.loadCertificateOrCRLFile(file, X509Utils.X509_FILETYPE_PEM) != 0 ? 1 : 0;
                     } else {
-                        ok = (ctx.loadCertificateOrCRLFile(X509Utils.getDefaultCertificateFile(), X509Utils.X509_FILETYPE_PEM) != 0) ? 1 : 0;
+                        ok = (ctx.loadDefaultJavaCACertsFile() != 0) ? 1: 0;
                     }
                     if (ok == 0) {
                         X509Error.addError(X509Utils.X509_R_LOADING_DEFAULTS);

--- a/src/java/org/jruby/ext/openssl/x509store/Store.java
+++ b/src/java/org/jruby/ext/openssl/x509store/Store.java
@@ -325,9 +325,9 @@ public class Store implements X509TrustManager {
 
     /**
      * c: X509_STORE_set_default_paths
-     * not used for now: invoking this method causes refering System.getenv("SSL_CERT_DIR") etc.
-     * We need to get the dir via evaluating "ENV['SSL_CERT_DIR']" instead of it.
-     */
+     *  We call this method only if there is no override specified in either
+     *  "ENV['SSL_CERT_DIR']" or "ENV['SSL_CERT_FILE']" 
+    */
     public int setDefaultPaths() throws Exception { 
         Lookup lookup;
 


### PR DESCRIPTION
This patch adds support for reading the Java cacerts keystore
to import the default trust anchors using the set_default_paths
API.  This patch addresses the problem discussed here:
http://jira.codehaus.org/browse/JRUBY-6140
